### PR TITLE
No underscore dangle

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ module.exports = {
     appendLoadFixtures: false,
     readFixtures: false,
     loadFixtures: false,
-    modulejs: false,
     preloadFixtures: false,
     spyOnEvent: false,
   },

--- a/index.js
+++ b/index.js
@@ -32,6 +32,6 @@ module.exports = {
   rules: {
     strict: 0,
     'func-names': 0,
-    'no-underscore-dangle': 0
+    'no-underscore-dangle': [ 0, { 'allowAfterThis': true } ]
   },
 };

--- a/index.js
+++ b/index.js
@@ -32,5 +32,6 @@ module.exports = {
   rules: {
     strict: 0,
     'func-names': 0,
+    'no-underscore-dangle': 0
   },
 };


### PR DESCRIPTION
Disabling no-underscore-dangle rule on eslint (http://eslint.org/docs/rules/no-underscore-dangle).

Now, we can use:

```JavaScript
this._myMethod();
this.myMethod_();
```

We are using `_` before functions that we call "private".

If there is some opposite opinion, please, let's discuss 😸 .