### PR TITLE
rule suggestion class-methods-use-this

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,10 @@ module.exports = {
   rules: {
     strict: 0,
     'func-names': 0,
-    curly: [ 'error', 'all' ],
-    'no-underscore-dangle': [ 0, { 'allowAfterThis': true } ]
+    curly: ['error', 'all'],
+    'no-underscore-dangle': [0, {
+      'allowAfterThis': true
+    }],
+    'class-methods-use-this': ['off', {}]
   },
 };


### PR DESCRIPTION
### class-methods-use-this
https://eslint.org/docs/rules/class-methods-use-this

Fazendo implementação da nova stack de front, me deparei com os seguintes `errors` do `eslint`:
`/*error Expected 'this' to be used by class method 'foo'.*/`

Essa regra exige o uso do ```this``` por métodos da classe.
Caso não use ele recomenda que o método seja ```static```.

O que vocês acham, muda a regra para off ou mantém e muda o método para ```static```
